### PR TITLE
update readme to reflect resolved pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,3 @@ add-on.
 # Known issues
 
 * This package is missing startups script for automatic execution on startup.
-* Due to an issue with one of the dependencies, some contacts, namely groups, will sometimes fail to work. Revelant PR: https://github.com/eventable/vobject/pull/77


### PR DESCRIPTION
The last line of the readme says that groups sometimes don't work due to an upstream bug, but that PR was merged a year ago. Was the fix pulled into EteSync, and therefore groups now work fine?