### PR TITLE
Docker pip upgrade and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,17 @@ The package `etesync-dav` is [available on AUR](https://aur.archlinux.org/packag
 
 ## Docker
 
-Clone this repo
+Run one time initial setup to persist the required configuration into a docker volume
 
-    git clone https://github.com/etesync/etesync-dav
-    cd etesync-dav
+    docker run -it --rm -v etesync:/data etesync/etesync-dav setup
 
-Build the Docker image
+Run etesync-dav in a background docker container with configuration from previous step
 
-    docker build . -t etesync-dav:latest
+    docker run --name etesync-dav -d -v etesync:/data -p 37358:37358 --restart=always etesync/etesync-dav
 
-Run setup and persist configuration into a docker volume
+Getting log output from container if you run into any issues
 
-    docker run -it --rm -v etesync:/data etesync-dav:latest setup
-
-Run etesync-dav server in background
-
-    docker run --name etesync-dav -d -v etesync:/data -p 37358:37358 --restart=always etesync-dav:latest
+    docker logs etesync-dav
 
 ## Windows systems
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,5 +6,8 @@ if [ "$1" == "setup" ]; then
   exit 0
 fi
 
+echo "Upgrading etesync-dav if necessary"
+pip install --upgrade etesync-dav
+
 echo "Running etesync-dav"
 etesync-dav


### PR DESCRIPTION
* Add pip upgrade into init script so latest version is always running regardless image version on duckerhub (since it is setup as a manual build process)
* Update Docker section of README with latest details

Some notes on this:
* You'll need to do another manual build and push of docker image to Dockerhub with this change included
* While the upgrade will at least handle the case of not having to always push a new container image to dockerhub on every release, it will still be nice to push once in a while. Otherwise, if there is a newer release available, every time the container is started or restarted it will need to upgrade packages (not the worst - just a little annoying).