### PR TITLE
Workaround for pip not choosing the latest dependencies

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,7 @@ if [ "$1" == "setup" ]; then
 fi
 
 echo "Upgrading etesync-dav if necessary"
-pip install --upgrade etesync-dav
+pip install --upgrade etesync etesync-dav radicale_storage_etesync
 
 echo "Running etesync-dav"
 etesync-dav


### PR DESCRIPTION
This is probably not the right fix but currently when installing etesync-dav with pip it doesn't pick up the newest version of underlying dependencies (e.g. etesync, radicale-storage-etesync). This was causing issues for syncing that looked like this:

`
[7f02c525f700] ERROR: An exception occurred during PROPPATCH request on '/email@domain.com/881b742xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/': get_meta() missing 1 required positional argument: 'key'
[7f02c525f700] ERROR: An exception occurred during PROPPATCH request on '/email@domain.com/881b742xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/': get_meta() missing 1 required positional argument: 'key'
`

So my workaround for now is to just force upgrade dependencies. I'm guessing this issue also exists in a normal python/virtualenv environment as well. A better fix would probably be forcing newer version requirements in each of the projects. Anyways, this is just my temporary workaround.
