### PR TITLE
Use exec in docker-entrypoint.sh so signals are forwarded

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,4 +10,4 @@ echo "Upgrading etesync-dav if necessary"
 pip install --upgrade etesync-dav
 
 echo "Running etesync-dav"
-etesync-dav
+exec etesync-dav


### PR DESCRIPTION
Without `exec` signals are not forwarded, so if docker sends a TERM signal etesync-dav will not stop. 
After a timeout docker sends a `KILL` signal, which stops it but there could be data loss.
Using `exec` solves this problem.