### PR TITLE
Systemd Unit file to install and start etesync-dav

### DIFF
--- a/examples/systemd-sandbox/Readme.md
+++ b/examples/systemd-sandbox/Readme.md
@@ -1,0 +1,92 @@
+# A Sandboxing Systemd Unit For Etesync-dav
+This is an example systemd unit file that installs and start etesync-dav.
+You will want to adapt it to your use case.
+
+To use etesync-dav via this unit you need to:
+* generate the credential files and configuration for Radicale
+* install the unit
+* start the unit
+* [connect your client to eyesync](https://github.com/etesync/etesync-dav])
+
+## FAQ
+### How should I generate the credential files and Radicale configuration?
+
+For each user ($USER is the user name of the remote etesync server) run the following (replace `etesync.example.org` with the URL of your server or remove it if you use the official EteSync server):
+`sudo systemd-run --pty -p DynamicUser=true -p DevicePolicy=closed -p CapabilityBoundingSet= -p NoNewPrivileges=true -p PrivateDevices=true -p 'RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6' -p ProtectHome=true -p ProtectSystem=strict -p InaccessiblePaths=/boot -E HOME=/tmp -p WorkingDirectory=/tmp -E ETESYNC_URL=https://etesync.example.org sh -c "pip3 install etesync-dav && .local/bin/etesync-dav-manage add $USER && echo >> .config/etesync-dav/etesync_creds && .local/bin/etesync-dav -H localhost:234; more .config/etesync-dav/* | cat "`
+
+It is normal see an error message `ERROR: An exception occurred during server startup: Failed to start server 'localhost:234': [Errno 13] Permission denied`.
+
+At the end of the `systemd-run`, `more` will show the contents of three files.  The contents should be pasted into files in `~/.config/etesync-dav`.
+
+### How can I install this unit?
+Symlink it to `/etc/systemd/system/etesync-dav@.service`
+and then run `sudo systemctl daemon-reload`.
+
+### How do I start this unit?
+For each user run `sudo systemctl enable etesync-dav@$USER` and `sudo systemctl start etesync-dav@$USER`.
+
+### Can this unit handle multiple users on the same host?
+Yes but each user will need a different port number in the `server`
+section of their `~/.config/etesync-dav/radicale.conf`.
+
+### How can I see the unit's logs?
+`journalctl -f -u etesync-dav@$USER`
+
+### Why does it install etesync-dav?
+This unit installs etesync-dav
+because etesync-dav is not available in Debian and somebody has to do the install.
+This keeps the starting and installation in one place and means that only the latest version of etesync-dav is ever started.
+
+### Why all the sandboxing systemd parameters?
+This unit installs many possibly untrusted dependencies.
+The sandboxing means that evil code does not have access to your files.
+Evil code can however steal your etesync password also well as stealing
+or modifying you calendar and contacts.
+
+### What about limiting network usage?
+This will be possible once
+[Add support for systemd socket activation](https://github.com/Kozea/Radicale/commit/2275ba4f9323e87eeac61f8811a4cc2773061e70)
+is available in etesync-dav.
+At that point a systemd socket file will open the network connection on localhost
+and etesync-dav can be limited to public IP address and the local DNS server.
+
+### Is there a race at startup?
+Yes as systemd thinks that the service is ready before it has opened its socket.
+This will be fixed by using a systemd socket unit.
+
+### What about stopping evil code from bitcoin mining?
+Perhaps CPUQuota should be reduced but this would slow down startup.
+
+### Why are the pip modules downloaded after every reboot?
+It does not seem worth the effort to find a place to keep them.
+
+### Why is the etesync cache lost on reboot?
+The data in the cache is not encrypted so it should only be saved to a encrypted disk.
+Fxixing this is a future project.
+
+### Is it a security risk that the etesync database is lost on reboot?
+Yes as the check for an evil server rewinding the database is lost.
+
+### Why is `MemoryDenyWriteExecute` not set?
+It causes SSL verification to fail.
+
+### What version of systemd does the unit work with?
+Systemd is a moving target, at the moment this unit is tested with 239, more recent version should work as well
+
+### Why install etesync-dav in /tmp rather than the run directory?
+The `/run` filesystem is mounted `noexec` and `pip3` `.so` libraries cannot be used when they are
+on a filesystem mounted `noexec`.
+
+### Can I increase the logging?
+Yes, use `sudo systemctl edit etesync-dav@$USER` to add `Environment=EYESYNC_DAV_ARGS=--debug` in the `[Service]` section.
+
+### Can I stop the messages from `pip3`?
+Yes, use `sudo systemctl edit etesync-dav@$USER` to add `Environment=PIP_ARGS=--quiet` in the `[Service]` section.
+
+### How can I get this unit to start after my encrypted home directory is available?
+Use `sudo systemctl edit etesync-dav@$USER` to add something like
+```
+[Install]
+WantedBy=
+WantedBy=home-%i.mount
+```

--- a/examples/systemd-sandbox/etesync-dav@.service
+++ b/examples/systemd-sandbox/etesync-dav@.service
@@ -1,0 +1,74 @@
+# A systemd Unit file to install and start etesync-dav.
+# This Unit is for those that want to isolate the etesync-dav code from
+# their system as much as possible, this is why DynamicUser and other
+# isolation options are present.
+# Debian does not provide etesync-dav so this unit installs it each time the service is started.
+# This will slow down startup but make it easier to have the most recent version.
+# The isolation options mean that the caches is not kept across reboots also slowing down startup.
+
+# Put this file in /etc/systemd/system/etesync-dav@.service and
+# create etesync-dav configuration files ~/.config/etesync-dav using
+# etesync-dav-manage in a VM or by copying them from another machine.
+#
+# sudo systemctl daemon-reload && sudo systemctl restart etesync-dav@$USER; systemctl status --no-pager etesync-dav@$USER
+# to set EYESYNC_DAV_ARGS or PIP_ARGS use: sudo systemctl edit etesync-dav@$USER
+# sudo systemctl enable etesync-dav@$USER
+# journalctl -f -u etesync-dav@$USER
+#
+# Developer notes:
+# With radicale master and libsystemd-dev will be able to use
+# systemd socket activation and thus avoid race conditions at startup:
+# https://github.com/Kozea/Radicale/commit/2275ba4f9323e87eeac61f8811a4cc2773061e70
+# Don't use the forking mode and the --daemon flag or logs go to /dev/null.
+[Unit]
+Description=EteSync CalDAV and CardDAV front-end/proxy for %i
+Documentation=https://github.com/etesync/etesync-dav
+After=network-online.target
+[Service]
+UMask=022
+RuntimeDirectory=%N
+RuntimeDirectoryMode=0700
+Environment=ETESYNC_CONFIG_DIR=%t/%N
+Environment=CONFFILES="radicale.conf htpaswd etesync_creds"
+WorkingDirectory=%t/%N
+# The pip3 install must be on a filesystem that is not mounted noexec, %t (/run) is mounted noexec
+Environment=HOME=/tmp/%N
+Environment=PIP_MODULES="pytz etesync-dav"
+ExecStartPre=+sh -c 'runuser -u %i -- sh -c "tar -C \\$HOME/.config/etesync-dav -hc $CONFFILES" > creds.tar'
+ExecStartPre=tar --unlink-first -f creds.tar -x
+ExecStartPre=sed -i -e "s^ = /.*/^ = ${ETESYNC_CONFIG_DIR}/^" radicale.conf
+ExecStartPre=mkdir -m 0700 $HOME
+ExecStartPre=pip3 --cache-dir %t/%N/pip3-cache $PIP_ARGS install $PIP_MODULES
+ExecStart=python3 ${HOME}/.local/bin/etesync-dav $EYESYNC_DAV_ARGS
+ExecStopPost=rm $CONFFILES creds.tar
+
+# Some of these isolation options are from https://radicale.org/setup/
+DynamicUser=true
+RuntimeDirectoryPreserve=true
+DevicePolicy=closed
+CapabilityBoundingSet=
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictRealtime=true
+#MemoryDenyWriteExecute=true
+SystemCallFilter=@system-service
+TemporaryFileSystem=/var:ro /docker:ro /media:ro /opt:ro
+InaccessiblePaths=/mnt /boot
+MemoryHigh=512M
+CPUQuota=90%
+TasksMax=10
+TimeoutStartSec=10m
+
+Restart=on-failure
+RestartSec=30min 1s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Systemd is another way to install and run etesync-dav, so add an example systemd unit file to the repo. The unit file uses systemd restrictions to isolate the etesync-dev process from other processes, users and files.