### PR TITLE
Added startup file for macOS.

### DIFF
--- a/examples/launchd/README.md
+++ b/examples/launchd/README.md
@@ -1,0 +1,14 @@
+======================
+Startup file for macOS
+======================
+
+`com.etesync.etesync-dav.plist` is an "agent configuration file" for
+macOS' `launchd`. (See the manual pages for `launchd`, `launchd.plist`,
+and `launchctl` for details.)
+
+You should place this file in:
+
+    ~/Library/LaunchAgents
+
+After doing so, `etesync-dav` will start automatically when you log in.
+Also, you can start and stop it via `launchctl`.

--- a/examples/launchd/com.etesync.etesync-dav.plist
+++ b/examples/launchd/com.etesync.etesync-dav.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.etesync.etesync-dav</string>
+    <key>Program</key>
+    <string>/usr/local/bin/etesync-dav</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+</dict>
+</plist>


### PR DESCRIPTION
This is a simple startup file for macOS' `launchd`. If it is placed in `~/Library/LaunchAgents` the eteSync DAV client starts automatically when the user logs in. It can then be controlled via `launchctl`.