### PR TITLE
Add section "Manual" under "macOS Mojave"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,35 @@ reconfigure `etesync-dav`. It also won't overwrite existing
 certificates. `--trust-cert` works on macOS 10.3 or newer only.
 See `etesync-dav-certgen --help` for details.
 
+### Manual
+
+Alternatively you can generate and configure a self-signed certificate manually with the following steps:
+
+1. Generate a self-signed certificate (valid for 10 years)
+
+````bash
+cd ~/Library/Application\ Support/etesync-dav
+openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=etesync.localhost" -keyout etesync.key -out etesync.crt
+````
+    
+2. Using `open` command triggers macOS "add to keychain" dialog (equivelent of double-clicking that file in Finder):
+
+````bash
+open etesync.crt
+````
+    
+3. In the dialog confirm adding to "login" keychain.
+4. Open `Keychain Access` app, find and open `etesync.localhost` (under Keychains: login, Category: Certificates), expand "Trust" and pick "Always trust" for SSL. 
+5. Edit `~/Library/Application\ Support/etesync-dav/radicale.conf`, under `[server]` enter the following to make it use the certificate (please replace **USERNAME** for your actual username):
+
+````ini
+    ssl = yes
+    certificate = /Users/USERNAME/Library/Application\ Support/etesync-dav/etesync.crt
+    key = /Users/USERNAME/Library/Application\ Support/etesync-dav/etesync.key
+````
+
+6. Restart `etesync-dav`
+
 ## iOS
 
 By default, iOS only syncs events 30 days old and newer, which may look as if


### PR DESCRIPTION
Describes how to generate and configure a self-signed certificate manually.