### PR TITLE
Fix bash code for manual ssl cert generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Alternatively you can generate and configure a self-signed certificate manually 
 1. Generate a self-signed certificate (valid for 10 years)
 
 ````bash
-cd "~/Library/Application Support/etesync-dav"
+cd ~/Library/Application\ Support/etesync-dav
 openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=etesync.localhost" -keyout etesync.key -out etesync.crt
 ````
     


### PR DESCRIPTION
The use of `~` in a quoted path is not possible:

```
bash-3.2$ cd "~/Library/Application Support/etesync-dav"
bash: cd: ~/Library/Application Support/etesync-dav: No such file or directory
```

One way is to move the `~` out of the quoted text. The other way is to escape the space with `\`. I went for the second :)