### PR TITLE
Correct config directory environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,16 @@ EteSync-DAV should automatically use the system's proxy settings if set correctl
 
 ## Config files
 
-`etesync-dav` stores data in the directory specified by the `CONFIG_DIR`
+`etesync-dav` stores data in the directory specified by the `ETESYNC_CONFIG_DIR`
 environment variable. This includes a database and the credentials cache.
 This directory is not relocatable, so if you change
-`CONFIG_DIR` you will need to regenerate these files (which means
+`ETESYNC_CONFIG_DIR` you will need to regenerate these files (which means
 reconfiguring clients). It may be possible to manually edit these files to
 the new path. Note that the database will just mirror the content of your
 main EteSync database so in most cases you should not lose anything if you
 delete it.
 
-`CONFIG_DIR` defaults to a subdirectory of the appropriate config directory
+`ETESYNC_CONFIG_DIR` defaults to a subdirectory of the appropriate config directory
 for your platform (`~/.config/etesync-dav` on Unix/Linux, see
 [appdirs](http://pypi.python.org/pypi/appdirs) module docs for where it
 will be on other platforms).


### PR DESCRIPTION
The correct environment variable here is `ETESYNC_CONFIG_DIR`, this
commit corrects the name of this variable in the documentation.

See https://github.com/etesync/etesync-dav/blob/master/etesync_dav/config.py#L6