### PR TITLE
Update radicale to 3.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'appdirs>=1.4.3',
         'etesync>=0.11.1',
-        'Radicale==3.0.2',
+        'Radicale==3.0.3',
         'Flask>=1.1.1',
         'Flask-WTF>=0.14.2',
     ]


### PR DESCRIPTION
Why is the version pinning so restrictive? Wouldn't `>=3,<4` suffice?