### PR TITLE
Update example systemd Unit to 245 and cache database & pip

### DIFF
--- a/examples/systemd-sandbox/Readme.md
+++ b/examples/systemd-sandbox/Readme.md
@@ -2,21 +2,19 @@
 This is an example systemd unit file that installs and start etesync-dav.
 You will want to adapt it to your use case.
 
+
 To use etesync-dav via this unit you need to:
-* generate the credential files and configuration for Radicale
 * install the unit
+
 * start the unit
-* [connect your client to etesync](https://github.com/etesync/etesync-dav)
+
+* create your local user with the [management UI](http://localhost:37358)
 
 ## FAQ
 ### How should I generate the credential files and Radicale configuration?
 
-For each user ($USER is the user name of the remote etesync server) run the following (replace `etesync.example.org` with the URL of your server or remove it if you use the official EteSync server):
-`sudo systemd-run --pty -p DynamicUser=true -p DevicePolicy=closed -p CapabilityBoundingSet= -p NoNewPrivileges=true -p PrivateDevices=true -p 'RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6' -p ProtectHome=true -p ProtectSystem=strict -p InaccessiblePaths=/boot -E HOME=/tmp -p WorkingDirectory=/tmp -E ETESYNC_URL=https://etesync.example.org sh -c "pip3 install etesync-dav && .local/bin/etesync-dav-manage add $USER && echo >> .config/etesync-dav/etesync_creds && .local/bin/etesync-dav -H localhost:234; more .config/etesync-dav/* | cat "`
-
-It is normal see an error message `ERROR: An exception occurred during server startup: Failed to start server 'localhost:234': [Errno 13] Permission denied`.
-
-At the end of the `systemd-run`, `more` will show the contents of three files.  The contents should be pasted into files in `~/.config/etesync-dav`.
+Create your local user with [management UI](http://localhost:37358) as described in the
+[readme](https://github.com/etesync/etesync-dav/blob/master/README.md#configuration-and-running)
 
 ### How can I install this unit?
 Symlink it to `/etc/systemd/system/etesync-dav@.service`
@@ -26,8 +24,12 @@ and then run `sudo systemctl daemon-reload`.
 For each user run `sudo systemctl enable etesync-dav@$USER` and `sudo systemctl start etesync-dav@$USER`.
 
 ### Can this unit handle multiple users on the same host?
-Yes but each user will need a different port number in the `server`
-section of their `~/.config/etesync-dav/radicale.conf`.
+Yes but each user will need to use a different port by setting ETESYNC_LISTEN_PORT using
+`sudo systemctl edit etesync-dav@$USER` to create
+```
+[Service]
+Environment=ETESYNC_LISTEN_PORT=45625
+```
 
 ### How can I see the unit's logs?
 `journalctl -f -u etesync-dav@$USER`
@@ -57,34 +59,40 @@ This will be fixed by using a systemd socket unit.
 ### What about stopping evil code from bitcoin mining?
 Perhaps CPUQuota should be reduced but this would slow down startup.
 
-### Why are the pip modules downloaded after every reboot?
-It does not seem worth the effort to find a place to keep them.
-
-### Why is the etesync cache lost on reboot?
-The data in the cache is not encrypted so it should only be saved to a encrypted disk.
-Fxixing this is a future project.
-
-### Is it a security risk that the etesync database is lost on reboot?
-Yes as the check for an evil server rewinding the database is lost.
+### Are the pip modules downloaded after every reboot?
+No they are cached and should be automatically cleaned.
 
 ### Why is `MemoryDenyWriteExecute` not set?
 It causes SSL verification to fail.
 
+### Is the etesync cache lost on reboot?
+No, howvever if your /var/cache is not on an encrypted disk, considering using
+`sudo systemctl edit etesync-dav@`
+to move the cache to /run (which is kept in memory).
+by adding `Environment=ETESYNC_DATA_DIR=%t/%N/data` with `sudo systemctl edit etesync-dav@`
+In this case you should
+```
+mkdir ~/.local/share/etesync-dav
+sudo cp /var/cache/etesync-dav@$USER/data/etesync_creds htpaswd ~/.local/share/etesync-dav/
+sudo chown $USER ~/.local/share/etesync-dav/*
+```
+so that the unit can copy the credentials into the volatile cache after each restart.
+
 ### What version of systemd does the unit work with?
-Systemd is a moving target, at the moment this unit is tested with 239, more recent version should work as well
+Systemd is a moving target, at the moment this unit is tested with 245, more recent version should work as well
 
 ### Why install etesync-dav in /tmp rather than the run directory?
 The `/run` filesystem is mounted `noexec` and `pip3` `.so` libraries cannot be used when they are
 on a filesystem mounted `noexec`.
 
 ### Can I increase the logging?
-Yes, use `sudo systemctl edit etesync-dav@$USER` to add `Environment=EYESYNC_DAV_ARGS=--debug` in the `[Service]` section.
+Yes, use `sudo systemctl edit etesync-dav@` to add `Environment=EYESYNC_DAV_ARGS=--debug` in the `[Service]` section.
 
 ### Can I stop the messages from `pip3`?
-Yes, use `sudo systemctl edit etesync-dav@$USER` to add `Environment=PIP_ARGS=--quiet` in the `[Service]` section.
+Yes, use `sudo systemctl edit etesync-dav@` to add `Environment=PIP_ARGS=--quiet` in the `[Service]` section.
 
 ### How can I get this unit to start after my encrypted home directory is available?
-Use `sudo systemctl edit etesync-dav@$USER` to add something like
+Use `sudo systemctl edit etesync-dav@` to add something like
 ```
 [Install]
 WantedBy=

--- a/examples/systemd-sandbox/etesync-dav@.service
+++ b/examples/systemd-sandbox/etesync-dav@.service
@@ -1,19 +1,16 @@
 # A systemd Unit file to install and start etesync-dav.
+#
 # This Unit is for those that want to isolate the etesync-dav code from
 # their system as much as possible, this is why DynamicUser and other
 # isolation options are present.
-# Debian does not provide etesync-dav so this unit installs it each time the service is started.
-# This will slow down startup but make it easier to have the most recent version.
-# The isolation options mean that the caches is not kept across reboots also slowing down startup.
+# This unit is tested on systemd-245.4-4 and etesync-dav-0.16.0
 
-# Put this file in /etc/systemd/system/etesync-dav@.service and
-# create etesync-dav configuration files ~/.config/etesync-dav using
-# etesync-dav-manage in a VM or by copying them from another machine.
-#
-# sudo systemctl daemon-reload && sudo systemctl restart etesync-dav@$USER; systemctl status --no-pager etesync-dav@$USER
-# to set EYESYNC_DAV_ARGS or PIP_ARGS use: sudo systemctl edit etesync-dav@$USER
-# sudo systemctl enable etesync-dav@$USER
-# journalctl -f -u etesync-dav@$USER
+# Put this file in /etc/systemd/system/etesync-dav@.service and run:
+#    sudo systemctl daemon-reload
+#    sudo systemctl restart etesync-dav@$USER
+#    sudo systemctl enable etesync-dav@$USER
+# With the management UI at http://localhost:37358/, create your local user,
+# and retrieve the url and password for your calendar client.
 #
 # Developer notes:
 # With radicale master and libsystemd-dev will be able to use
@@ -24,23 +21,21 @@
 Description=EteSync CalDAV and CardDAV front-end/proxy for %i
 Documentation=https://github.com/etesync/etesync-dav
 After=network-online.target
+
 [Service]
 UMask=022
 RuntimeDirectory=%N
-RuntimeDirectoryMode=0700
-Environment=ETESYNC_CONFIG_DIR=%t/%N
-Environment=CONFFILES="radicale.conf htpaswd etesync_creds"
-WorkingDirectory=%t/%N
+CacheDirectory=%N
 # The pip3 install must be on a filesystem that is not mounted noexec, %t (/run) is mounted noexec
-Environment=HOME=/tmp/%N
-Environment=PIP_MODULES="pytz etesync-dav"
-ExecStartPre=+sh -c 'runuser -u %i -- sh -c "tar -C \\$HOME/.config/etesync-dav -hc $CONFFILES" > creds.tar'
-ExecStartPre=tar --unlink-first -f creds.tar -x
-ExecStartPre=sed -i -e "s^ = /.*/^ = ${ETESYNC_CONFIG_DIR}/^" radicale.conf
-ExecStartPre=mkdir -m 0700 $HOME
-ExecStartPre=pip3 --cache-dir %t/%N/pip3-cache $PIP_ARGS install $PIP_MODULES
-ExecStart=python3 ${HOME}/.local/bin/etesync-dav $EYESYNC_DAV_ARGS
-ExecStopPost=rm $CONFFILES creds.tar
+Environment=HOME=%T/%N
+Environment=ETESYNC_DATA_DIR=%C/%N/data
+Environment=PIP_MODULES=etesync-dav
+Environment=CONFFILES="htpaswd etesync_creds"
+ExecStartPre=mkdir -p -m 0700 $HOME $ETESYNC_DATA_DIR
+ExecStartPre=+sh -c 'runuser -u %i -- sh -c "tar -C \\$HOME/.local/share/etesync-dav -hc $CONFFILES || tar -c --files-from /dev/null" > %t/%N/creds.tar'
+ExecStartPre=tar -C ${ETESYNC_DATA_DIR} --unlink-first -f %t/%N/creds.tar -x
+ExecStartPre=pip3 --cache-dir %C/%N/pip3-cache $PIP_ARGS install --no-warn-script-location $PIP_MODULES
+ExecStart=%T/%N/.local/bin/etesync-dav $EXTRA_ARGS
 
 # Some of these isolation options are from https://radicale.org/setup/
 DynamicUser=true
@@ -58,13 +53,13 @@ ProtectKernelTunables=true
 ProtectSystem=strict
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictRealtime=true
-#MemoryDenyWriteExecute=true
+# MemoryDenyWriteExecute=true
 SystemCallFilter=@system-service
-TemporaryFileSystem=/var:ro /docker:ro /media:ro /opt:ro
+TemporaryFileSystem=/docker:ro /media:ro /opt:ro
 InaccessiblePaths=/mnt /boot
 MemoryHigh=512M
 CPUQuota=90%
-TasksMax=10
+TasksMax=50
 TimeoutStartSec=10m
 
 Restart=on-failure


### PR DESCRIPTION
Etesync's database is now on a filesystem that is preserved over
reboots. If this filesystem, /var/cache, is not encrypted, follow the Readme to
move it /run.

Pip files are cached over reboots.

This systemd unit works with systemd version 245