### PR TITLE
default modern UI to avoid needless login failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a CalDAV and CardDAV adapter for [EteSync](https://www.etesync.com)
 This package provides a local CalDAV and CardDAV server that acts as an EteSync compatibility layer (adapter).
 It's meant for letting desktop CalDAV and CardDAV clients such as Thunderbird, Outlook and Apple Contacts connect with EteSync.
 
-If all you want is to access your data from a computer, you are probably better off using [the web app](https://client.etesync.com).
+If all you want is to access your data from a computer, you are probably better off using [the web app](https://pim.etesync.com).
 
 # Installation
 


### PR DESCRIPTION
just aligns to the warning banner on the old client UI that says you should use https://pim.etesync.com