### PR TITLE
Support Radicale 3.1.0

### DIFF
--- a/etesync_dav/radicale_main/__init__.py
+++ b/etesync_dav/radicale_main/__init__.py
@@ -53,7 +53,7 @@ def run(passed_args=None):
 
     groups = {}
 
-    _, version_minor, _ = VERSION.split('.')
+    version_major, version_minor, _ = VERSION.split('.')
 
     for section, values in config.DEFAULT_CONFIG_SCHEMA.items():
         if section.startswith("_"):

--- a/etesync_dav/radicale_main/__init__.py
+++ b/etesync_dav/radicale_main/__init__.py
@@ -74,7 +74,7 @@ def run(passed_args=None):
                 del kwargs["internal"]
 
             if kwargs["type"] == bool:
-                if int(version_minor) >= 1:  # Changed since 3.1.0
+                if int(version_major) >= 3 and int(version_minor) >= 1:  # Changed since 3.1.0
                     del kwargs["type"]
                     opposite_args = list(kwargs.pop("opposite_aliases", ()))
                     opposite_args.append("--no%s" % long_name[1:])


### PR DESCRIPTION
Radicale 3.1.0 changed the way the arguments of ArgParse are set.
I updated them analogously to the Radicale [config.py](https://github.com/Kozea/Radicale/blob/master/radicale/config.py)

Fixes #244 