### PR TITLE
Support radicale 3.2.2

### DIFF
--- a/etesync_dav/radicale_main/__init__.py
+++ b/etesync_dav/radicale_main/__init__.py
@@ -107,7 +107,7 @@ def run(passed_args=None):
         args.logging_level = "debug"
     with contextlib.suppress(ValueError):
         log.set_level(config.DEFAULT_CONFIG_SCHEMA["logging"]["level"]["type"](
-            args.logging_level))
+            args.logging_level), True)
 
     # Update Radicale configuration according to arguments
     arguments_config = {}
@@ -133,7 +133,7 @@ def run(passed_args=None):
         sys.exit(1)
 
     # Configure logging
-    log.set_level(configuration.get("logging", "level"))
+    log.set_level(configuration.get("logging", "level"), configuration.get("logging", "backtrace_on_debug"))
 
     # Log configuration after logger is configured
     for source, miss in configuration.sources():


### PR DESCRIPTION
- add changes to log.set_level() from upstream radicale update (additional second arg - backtrace_on_debug):
https://www.github.com/Kozea/Radicale/pull/1519

Fixes runtime error using radicale 3.2.2:
```text
Traceback (most recent call last):
  File "/nix/store/wd2by7xjf0cx15nwdxg395x0zsfja50g-etesync-dav-0.32.1/bin/.etesync-dav-wrapped", line 164, in <module>
    radicale_main.run(radicale_args + sys.argv[1:])
  File "/nix/store/wd2by7xjf0cx15nwdxg395x0zsfja50g-etesync-dav-0.32.1/lib/python3.12/site-packages/etesync_dav/radicale_main/__init__.py", line 136, in run
    log.set_level(configuration.get("logging", "level"))
TypeError: set_level() missing 1 required positional argument: 'backtrace_on_debug'
```

Probably not worth merging as is, because it breaks runtime with radicale versions before 3.2.2 in the opposite way:
```text
Traceback (most recent call last):
  File "/nix/store/l6s0cp2x0gbbrbxykfjb0v78gzq3q12w-etesync-dav-0.32.1/bin/.etesync-dav-wrapped", line 164, in <module>
    radicale_main.run(radicale_args + sys.argv[1:])
  File "/nix/store/l6s0cp2x0gbbrbxykfjb0v78gzq3q12w-etesync-dav-0.32.1/lib/python3.12/site-packages/etesync_dav/radicale_main/__init__.py", line 136, in run
    log.set_level(configuration.get("logging", "level"), configuration.get("logging", "backtrace_on_debug"))
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/diygrl5c0fqqp5mgrhmcckqrwka54krd-radicale-3.2.1/lib/python3.12/site-packages/radicale/config.py", line 418, in get
    raise KeyError(section, option)
KeyError: ('logging', 'backtrace_on_debug')
```
There could be some way to check and do conditional instead.