### PR TITLE
Add pyscrypt dependency for macOS (fixes #332)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 
 import codecs
 import re
-import platform
 from os import path
 
 from setuptools import find_packages, setup

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ INSTALL_REQUIRES = [
     "Flask-WTF>=1.2.0,<2.0.0",
     "requests[socks]>=2.21",
     'pyobjc-framework-Cocoa>=7.0.0 ; sys_platform=="darwin"',
-    'pyscrypt>=1.2.6 ; sys_platform=="darwin"'
+    'pyscrypt>=1.2.6 ; sys_platform=="darwin"',
 ]
 
 KEYWORDS = ["etesync", "encryption", "sync", "pim", "caldav", "carddav"]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 
 import codecs
 import re
+import platform
 from os import path
 
 from setuptools import find_packages, setup
@@ -111,6 +112,7 @@ INSTALL_REQUIRES = [
     "Flask-WTF>=1.2.0,<2.0.0",
     "requests[socks]>=2.21",
     'pyobjc-framework-Cocoa>=7.0.0 ; sys_platform=="darwin"',
+    'pyscrypt>=1.2.6 ; sys_platform=="darwin"'
 ]
 
 KEYWORDS = ["etesync", "encryption", "sync", "pim", "caldav", "carddav"]


### PR DESCRIPTION
I added a `pyscrypt` dependency when `sys_platform == "darwin"` (`scrypt` throws a build error). This fixes #332. If you either update etebase on PyPI to v31.0.8 or the build in instructions for the runner to use etebase v31.0.8, etesync-dav should build on Apple Silicon using the macOS 14 runner.