### PR TITLE
Enable ARM builds for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, ubuntu-22.04-arm]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-13,  ubuntu-22.04-arm]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyinstaller/bundle.sh
+++ b/pyinstaller/bundle.sh
@@ -20,6 +20,7 @@ pyinstaller \
 
 # Travis stuff
 mkdir -p deploy
+ARCH=$(uname -m)
 if [ "$RUNNER_OS" = "Linux" ]; then
     ./dist/etesync-dav --version  # Sanity test on Linux and mac, can't do on windows
     if [ "$ARCH" = "x86_64" ]; then

--- a/pyinstaller/bundle.sh
+++ b/pyinstaller/bundle.sh
@@ -22,7 +22,15 @@ pyinstaller \
 mkdir -p deploy
 if [ "$RUNNER_OS" = "Linux" ]; then
     ./dist/etesync-dav --version  # Sanity test on Linux and mac, can't do on windows
-    mv dist/etesync-dav "deploy/linux-amd64-etesync-dav"
+    if [ "$ARCH" = "x86_64" ]; then
+        mv dist/etesync-dav "deploy/linux-amd64-etesync-dav"
+    elif [ "$ARCH" = "aarch64" ]; then
+        mv dist/etesync-dav "deploy/linux-arm64-etesync-dav"
+    else
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+    fi
+
 fi
 if [ "$RUNNER_OS" = "macOS" ]; then
     ./dist/etesync-dav --version  # Sanity test on Linux and mac, can't do on windows


### PR DESCRIPTION
Activates the Ubuntu-22.04-arm based runner.  Also adds logic so that the deployed binary for ARM does not have `amd64` in the file name

Tested the Github Action on my fork and have the built binary running on my Raspberry PI, confirmed that it is able to add an item to my calendar. Not sure if there's any more extensive tests we would want.
[CI](https://github.com/Michael-Gallo/etesync-dav/actions/runs/12942305049)
[Build](https://github.com/Michael-Gallo/etesync-dav/actions/runs/12942309029)
![image](https://github.com/user-attachments/assets/20576b12-01de-4218-803d-434d5f3edcc6)
![image](https://github.com/user-attachments/assets/d89f2d42-18c3-48dc-a88d-5b72f0716d4a)



As a complete aside, I would have liked to fix issue #229 with this PR as well and activate ARM for Mac, however it fails to build the wheel for etebase

![image](https://github.com/user-attachments/assets/91468fe1-24fe-4acf-b892-60b0a7fe6b72)
