### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ TbSync includes address book support (Lightning does not), automatically discove
 2. Open http://localhost:37358 in a browser, log in with your username and account password (not encryption password), and click on the link to your DAV colection to see a list of all the calendars, tasks lists, and address books in that collection
 3. For each item in the collection that you want to sync, copy the \[link] address and subscribe to that address in Thunderbird using `File > New Calendar > On the Network > CalDav` for calendars and tasks, or `New Address Book > Remote > CardDav` in Cardbook for address books
 
-### Evolution / GNOME Calendar / GNOME Contacts
-GNOME Calendar and Contacts do not support adding WebDAV calendars and address books directly, but you can add them in Evolution and they will appear correctly in all the apps.
+### Evolution / GNOME Contacts
+GNOME Contacts does not support adding WebDAV calendars and address books directly, but you can add them in Evolution and they will appear correctly in all the apps.
 
 1. Open Evolution and click File -> New -> Collection account
 2. Put your username in the user field.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ TbSync includes address book support (Lightning does not), automatically discove
 2. Open http://localhost:37358 in a browser, log in with your username and account password (not encryption password), and click on the link to your DAV colection to see a list of all the calendars, tasks lists, and address books in that collection
 3. For each item in the collection that you want to sync, copy the \[link] address and subscribe to that address in Thunderbird using `File > New Calendar > On the Network > CalDav` for calendars and tasks, or `New Address Book > Remote > CardDav` in Cardbook for address books
 
-### Evolution / GNOME Contacts
-GNOME Contacts does not support adding WebDAV calendars and address books directly, but you can add them in Evolution and they will appear correctly in all the apps.
+### Evolution / GNOME Contacts / GNOME Calendar
+GNOME Contacts does not support adding remote address books directly, but you can add them in Evolution and they will appear correctly in all the apps. GNOME Calendar does support adding webdav calendars directly in GNOME Calendar. Calendars can also be added in Evolution and they will appear correctly in all the apps.
 
 1. Open Evolution and click File -> New -> Collection account
 2. Put your username in the user field.


### PR DESCRIPTION
Remove mention of GNOME Calendar not supporting adding WebDAV calendars directly.

etesync-dav calendars can be added directly in GNOME Calendar version 47. 
 
I did not test if address books can be added directly in GNOME Contacts.