### PR TITLE
Fix usage with radicale >= 3.5.1

### DIFF
--- a/etesync_dav/radicale/storage.py
+++ b/etesync_dav/radicale/storage.py
@@ -605,7 +605,7 @@ class Storage(BaseStorage):
         raise NotImplementedError
 
     @contextmanager
-    def acquire_lock(self, mode, user=None):
+    def acquire_lock(self, mode, user=None, *args, **kwargs):
         """Set a context manager to lock the whole storage.
 
         ``mode`` must either be "r" for shared access or "w" for exclusive


### PR DESCRIPTION
Radicale changed `acquire_lock` in `3.5.1` to take a `*args, **kwargs`.

If using etesync-dav with a radicale >= 3.5.1, then writes can no longer be performed due to an error as described in #349.

Users of NixOS have the packaged etesync-dav using radicale `3.5.5` (tested working).

This PR would close #349, and should be backwards compatible since we don't use any arguments from *args or **kwargs.