### PR TITLE
fix compatibility with radicale >= 3.5.9

### DIFF
--- a/etesync_dav/radicale_main/server.py
+++ b/etesync_dav/radicale_main/server.py
@@ -53,13 +53,13 @@ elif os.name == "nt":
 
 
 class MyApplication(Application):
-    def do_POST(self, environ, base_prefix, path, user):
+    def do_POST(self, environ, base_prefix, path, user, remote_host="", user_agent=""):
         """Manage POST request."""
         # Dispatch .web URL to web module
         if path == "/.web" or path.startswith("/.web/"):
             return self._web.post(environ, base_prefix, path, user)
 
-        return super().do_POST(environ, base_prefix, path, user)
+        return super().do_POST(environ, base_prefix, path, user, remote_host, user_agent)
 
 
 def format_address(address):


### PR DESCRIPTION
2 arguments were added for radicale server connections,
simple fix, mostly workaround by passing empty strings

relevant radicale commit:
https://github.com/Kozea/Radicale/commit/1c7ff414a96a6024616f1ece1d473bebd0455206