### PR TITLE
Support peewee 4.x

### DIFF
--- a/etesync_dav/local_cache/__init__.py
+++ b/etesync_dav/local_cache/__init__.py
@@ -62,7 +62,7 @@ class Etebase:
             self.user, created = models.User.get_or_create(username=self.username)
 
     def _init_db(self, db_path):
-        from playhouse.sqlite_ext import SqliteExtDatabase
+        from peewee import SqliteDatabase as SqliteExtDatabase
 
         directory = os.path.dirname(db_path)
         if directory != "" and not os.path.exists(directory):


### PR DESCRIPTION
peewee 4.0 removed playhouse.sqlite_ext.SqliteExtDatabase; its functionality folded into peewee.SqliteDatabase, which already accepts the `pragmas=` kwarg. Aliasing at the import site keeps the call site identical and remains backwards compatible with peewee 3.x.

Fixes ImportError: cannot import name 'SqliteExtDatabase' from 'playhouse.sqlite_ext' on peewee >= 4.0.